### PR TITLE
Handle order loading errors

### DIFF
--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -3,10 +3,17 @@ import { createBrowserClient } from '@supabase/ssr';
 import type { Database } from './types';
 
 export function createClient() {
-  return createBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !key) {
+    console.error(
+      'Supabase envs ausentes: defina NEXT_PUBLIC_SUPABASE_URL e NEXT_PUBLIC_SUPABASE_ANON_KEY'
+    );
+    throw new Error('Configuração Supabase inválida: variáveis de ambiente ausentes');
+  }
+
+  return createBrowserClient<Database>(url, key);
 }
 
 // Para compatibilidade com código existente


### PR DESCRIPTION
Add a guard to `createClient` to throw an explicit error if Supabase environment variables are missing.

This prevents cryptic "No API key found in request" errors from Supabase by providing a clear message when `NEXT_PUBLIC_SUPABASE_URL` or `NEXT_PUBLIC_SUPABASE_ANON_KEY` are not set, which often occurs in preview deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-a60cd251-bb7f-49c8-af85-4c085b929c3b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a60cd251-bb7f-49c8-af85-4c085b929c3b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

