### PR TITLE
Handle supabase profile fetch error

### DIFF
--- a/app/(public)/signin/page.tsx
+++ b/app/(public)/signin/page.tsx
@@ -30,7 +30,7 @@ export default function SignInPage() {
       const { data: profile } = await supabase
         .from('profiles')
         .select('role')
-        .eq('id', data.user.id)
+        .eq('user_id', data.user.id)
         .single();
 
       // Redirect based on role


### PR DESCRIPTION
Align profile fetch with Supabase schema by querying `profiles` table with `user_id` instead of `id`.

---
<a href="https://cursor.com/background-agent?bcId=bc-14a6abff-e2a5-40a9-98a6-a0e4bd80311b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14a6abff-e2a5-40a9-98a6-a0e4bd80311b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

