### PR TITLE
Handle forbidden user list error

### DIFF
--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { createServerSupabase } from '@/lib/supabase/server';
+
+async function requireAdmin() {
+	const supabase = createServerSupabase();
+	const { data: { user } } = await supabase.auth.getUser();
+	if (!user) return { ok: false as const, status: 401 };
+	const { data: profile } = await supabase
+		.from('profiles')
+		.select('role')
+		.eq('user_id', user.id)
+		.maybeSingle();
+	if (!profile || profile.role !== 'admin') return { ok: false as const, status: 403 };
+	return { ok: true as const };
+}
+
+export async function GET(req: NextRequest) {
+	const guard = await requireAdmin();
+	if (!guard.ok) return NextResponse.json({ error: 'Forbidden' }, { status: guard.status });
+
+	const { searchParams } = new URL(req.url);
+	const page = Number(searchParams.get('page') ?? '1');
+	const perPage = Number(searchParams.get('perPage') ?? '200');
+
+	const admin = createAdminClient();
+	const { data, error } = await admin.auth.admin.listUsers({ page, perPage });
+	if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+
+	return NextResponse.json(data);
+}
+
+export async function POST(req: NextRequest) {
+	const guard = await requireAdmin();
+	if (!guard.ok) return NextResponse.json({ error: 'Forbidden' }, { status: guard.status });
+
+	const body = await req.json();
+	const { email, password, email_confirm } = body ?? {};
+	if (!email || !password) {
+		return NextResponse.json({ error: 'email and password are required' }, { status: 400 });
+	}
+
+	const admin = createAdminClient();
+	const { data, error } = await admin.auth.admin.createUser({ email, password, email_confirm: !!email_confirm });
+	if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+
+	return NextResponse.json(data);
+}
+
+export async function DELETE(req: NextRequest) {
+	const guard = await requireAdmin();
+	if (!guard.ok) return NextResponse.json({ error: 'Forbidden' }, { status: guard.status });
+
+	const { searchParams } = new URL(req.url);
+	const userId = searchParams.get('userId');
+	if (!userId) return NextResponse.json({ error: 'userId is required' }, { status: 400 });
+
+	const admin = createAdminClient();
+
+	// Delete profile first (idempotent)
+	await admin.from('profiles').delete().eq('user_id', userId);
+
+	const { error } = await admin.auth.admin.deleteUser(userId);
+	if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+
+	return new NextResponse(null, { status: 204 });
+}
+

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from './types';
+
+export function createAdminClient() {
+	const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+	const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+	if (!url || !serviceKey) {
+		throw new Error('Missing SUPABASE envs: NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+	}
+
+	return createClient<Database>(url, serviceKey, {
+		auth: { autoRefreshToken: false, persistSession: false }
+	});
+}


### PR DESCRIPTION
Move Supabase admin user management operations to server-side API routes to resolve 403 Forbidden errors and enhance security.

Client-side calls to `supabase.auth.admin.*` were failing with a 403 error because they require the `SUPABASE_SERVICE_ROLE_KEY`, which must only be used server-side. This change creates secure server-side endpoints for these operations, protected by an admin role check.

---
<a href="https://cursor.com/background-agent?bcId=bc-252ce351-f7e1-4417-b965-c02aab162b8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-252ce351-f7e1-4417-b965-c02aab162b8b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

