### PR TITLE
Handle api user loading error

### DIFF
--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -240,7 +240,14 @@ export default function AdminPage() {
             email_confirm: true
           })
         });
-        if (!res.ok) throw new Error('Falha ao criar usuário');
+        if (!res.ok) {
+          let message = 'Falha ao criar usuário';
+          try {
+            const err = await res.json();
+            if (err?.error) message = err.error;
+          } catch {}
+          throw new Error(message);
+        }
         const authData = await res.json();
 
         // Criar perfil do usuário
@@ -252,7 +259,12 @@ export default function AdminPage() {
             role: userData.role,
             room_id: userData.room_id || null
           });
-        if (profileError) throw profileError;
+        if (profileError) {
+          try {
+            await fetch(`/api/admin/users?userId=${encodeURIComponent(authData.user.id)}`, { method: 'DELETE' });
+          } catch {}
+          throw profileError;
+        }
       } else {
         // Atualizar apenas o perfil (não podemos alterar email no auth facilmente)
         const { error: profileError } = await supabase

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -42,7 +42,17 @@ export async function POST(req: NextRequest) {
 
 	const admin = createAdminClient();
 	const { data, error } = await admin.auth.admin.createUser({ email, password, email_confirm: !!email_confirm });
-	if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+	if (error) {
+		// Map common Supabase auth errors to HTTP codes
+		const msg = (error.message || '').toLowerCase();
+		const status =
+			msg.includes('already registered') || msg.includes('user already') || msg.includes('duplicate')
+				? 409
+			: msg.includes('invalid') || msg.includes('password') || msg.includes('schema')
+				? 422
+			: 400;
+		return NextResponse.json({ error: error.message }, { status });
+	}
 
 	return NextResponse.json(data);
 }


### PR DESCRIPTION
Improve user creation error handling and data consistency by surfacing specific API errors and rolling back auth user creation if profile insertion fails.

The previous implementation returned a generic "Falha ao criar usuário" message and could leave a partially created user (auth user without a profile) if the profile insertion failed. This PR addresses these issues by providing more informative error messages from the API (e.g., for duplicate emails) and ensuring atomicity of the user creation process.

---
<a href="https://cursor.com/background-agent?bcId=bc-d52e71ca-9256-44cc-bfe2-7cbe13813563">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d52e71ca-9256-44cc-bfe2-7cbe13813563">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

