### PR TITLE
Corrigir exibição de usuários na administração

### DIFF
--- a/app/(app)/admin/page.tsx
+++ b/app/(app)/admin/page.tsx
@@ -49,7 +49,7 @@ export default function AdminPage() {
   const [user, setUser] = useState<any>(null);
   const [userProfile, setUserProfile] = useState<any>(null);
   const [userSearchTerm, setUserSearchTerm] = useState('');
-  const [userRoleFilter, setUserRoleFilter] = useState<string>('all');
+  const [userRoleFilter, setUserRoleFilter] = useState<string>('');
   
   const supabase = useMemo(() => createClient(), []);
 


### PR DESCRIPTION
Set the default user role filter to an empty string to correctly display all users in the Admin Users page.

The previous default value `'all'` for `userRoleFilter` was not being correctly interpreted by the filtering logic, resulting in no users being displayed by default. Changing it to `''` ensures that all users are shown when the page loads.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4875816-5a09-4d97-9ee1-26238c65a334">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4875816-5a09-4d97-9ee1-26238c65a334">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

