### PR TITLE
Fix pharmacy screen status transition and order notification

### DIFF
--- a/lib/hooks/useRealtimeOrders.ts
+++ b/lib/hooks/useRealtimeOrders.ts
@@ -113,8 +113,8 @@ export function useRealtimeOrders(options: UseRealtimeOrdersOptions = {}) {
       setOrders(enrichedOrders);
       lastFetchRef.current = Date.now();
       
-      // Tocar som se houver novos pedidos
-      if (newCount > previousCount && previousCount > 0) {
+      // Tocar som se houver novos pedidos (inclui o primeiro)
+      if (newCount > previousCount) {
         audioRef.current?.play().catch(() => {});
       }
       


### PR DESCRIPTION
Fixes "Transição de status inválida" on pharmacy screen and enables real-time new order display with sound.

The "Avançar" button could trigger an invalid status transition if an order was 'submitted' but not yet assigned. This PR introduces auto-claiming for such orders and disables the button until claimed. Additionally, new orders were not automatically appearing with sound, so the real-time hook was adjusted to play sound for all new orders and audio priming was added for browser compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-021c9c1d-225f-4e4f-8d13-f926173e5a45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-021c9c1d-225f-4e4f-8d13-f926173e5a45">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

